### PR TITLE
Suggestions to improve auto / drive

### DIFF
--- a/2024Crescendo/src/main/java/frc/robot/Constants.java
+++ b/2024Crescendo/src/main/java/frc/robot/Constants.java
@@ -13,6 +13,7 @@ import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 public final class Constants {
   public static class Xbox { 
     public static final int DRIVER_CONTROLLER_PORT = 0, OPERATOR_CONTROLLER_PORT = 1;
+    public static final double DRIVER_DEADBAND = 0.02;
   }
 
   public static class AmpBar { //TODO: change values!
@@ -193,5 +194,11 @@ public final class Constants {
     public static final double DEGREES_TO_REVOLUTIONS = 1.0/360.0;
     public static final double INTAKE_SAFE = 110 * Constants.Pivot.DEGREES_TO_REVOLUTIONS;
     public static final double INTAKE_DOWN = 6 * Constants.Pivot.DEGREES_TO_REVOLUTIONS;
+  }
+
+  public static class ExperimentalFeatures {
+    public static final boolean useCosineCompensation = false;
+    public static final boolean disableRotationWhenNotMoving = false;
+    public static final boolean applyDriverDeadband = false;
   }
 }

--- a/2024Crescendo/src/main/java/frc/robot/Constants.java
+++ b/2024Crescendo/src/main/java/frc/robot/Constants.java
@@ -200,5 +200,11 @@ public final class Constants {
     public static final boolean useCosineCompensation = false;
     public static final boolean disableRotationWhenNotMoving = false;
     public static final boolean applyDriverDeadband = false;
+
+    // Setting this to true because that's how the code works, but there's no reason to do this AFAICT, and
+    // it causes unnecessary CAN traffic. Each call to the 4 modules is BLOCKING. CTRE says:
+    // "We recommend that users avoid calling this API periodically"
+    // So this should really be set to FALSE.
+    public static final boolean applyNeutralModeConstantlyInAuto = true;
   }
 }

--- a/2024Crescendo/src/main/java/frc/robot/MathHelper.java
+++ b/2024Crescendo/src/main/java/frc/robot/MathHelper.java
@@ -1,0 +1,14 @@
+package frc.robot;
+
+// WPILib alreaday claimed MathUtil.
+public class MathHelper {
+    public static final double kEpsilon = 1e-12;
+
+    public static boolean epsilonEquals(double a, double b, double epsilon) {
+        return (a - epsilon <= b) && (a + epsilon >= b);
+    }
+
+    public static boolean epsilonEquals(double a, double b) {
+        return epsilonEquals(a, b, kEpsilon);
+    }
+}

--- a/2024Crescendo/src/main/java/frc/robot/Robot.java
+++ b/2024Crescendo/src/main/java/frc/robot/Robot.java
@@ -101,7 +101,10 @@ public class Robot extends TimedRobot {
   @Override
   public void autonomousPeriodic() {
     //TODO: apparently slows autos down excessively, have to test
-    m_robotContainer.swerve.setNeutralMode(true);
+    // There's no reason to do this. We setup neutral mode in auto init above.
+    if (Constants.ExperimentalFeatures.applyNeutralModeConstantlyInAuto) {
+      m_robotContainer.swerve.setNeutralMode(true);
+    }
   }
 
   @Override

--- a/2024Crescendo/src/main/java/frc/robot/commands/SwerveDrive.java
+++ b/2024Crescendo/src/main/java/frc/robot/commands/SwerveDrive.java
@@ -32,9 +32,10 @@ public class SwerveDrive extends Command {
 
   @Override
   public void execute() {
-    double xSpeed = cleanAndScaleInput(0.00, xSupplier.getAsDouble(), xLimiter, Constants.Swerve.SWERVE_MAX_SPEED);
-    double ySpeed = cleanAndScaleInput(0.00, ySupplier.getAsDouble(), yLimiter, Constants.Swerve.SWERVE_MAX_SPEED);
-    double rotationSpeed = cleanAndScaleInput(0.00, rotationSupplier.getAsDouble(), rotationLimiter, Constants.Swerve.SWERVE_ROTATION_MAX_SPEED_IN_RAD);
+    double deadband = Constants.ExperimentalFeatures.applyDriverDeadband ? Constants.Xbox.DRIVER_DEADBAND : 0.0;
+    double xSpeed = cleanAndScaleInput(deadband, xSupplier.getAsDouble(), xLimiter, Constants.Swerve.SWERVE_MAX_SPEED);
+    double ySpeed = cleanAndScaleInput(deadband, ySupplier.getAsDouble(), yLimiter, Constants.Swerve.SWERVE_MAX_SPEED);
+    double rotationSpeed = cleanAndScaleInput(deadband, rotationSupplier.getAsDouble(), rotationLimiter, Constants.Swerve.SWERVE_ROTATION_MAX_SPEED_IN_RAD);
     ChassisSpeeds chassisSpeeds = ChassisSpeeds.fromFieldRelativeSpeeds(xSpeed, ySpeed, rotationSpeed, swerve.pGetRotation2d());
     SwerveModuleState[] moduleState = Constants.Swerve.SWERVE_DRIVE_KINEMATICS.toSwerveModuleStates(chassisSpeeds);
     swerve.setModuleStates(moduleState);   

--- a/2024Crescendo/src/main/java/frc/robot/modules/SwerveModule.java
+++ b/2024Crescendo/src/main/java/frc/robot/modules/SwerveModule.java
@@ -188,8 +188,10 @@ public class SwerveModule {
         Rotation2d currentAngle = this.getState().angle;
         var optimized = optimize(state, currentAngle);
         double velocityToSet = optimized.speedMetersPerSecond;
+
         if (Constants.ExperimentalFeatures.disableRotationWhenNotMoving && MathHelper.epsilonEquals(velocityToSet, 0.0)) {
-            // Only command the steer controller to move if the robot is trying to move
+            // Only command the steer controller to move if the robot is trying to move. It's important that this
+            // be checked *before* adjusting the speed of the wheel based on cosine compensation.
             // Maybe we should be commanding it to keep it's current position instead in this case? 
             steerController.setControl(idleControlRequest);
         } else {


### PR DESCRIPTION
Based on the weird behavior of the wheels we looked at yesterday, I have some suggestions. I _believe_ it's the case that if you merge this, nothing will actually change. However, there is a Constants.ExperimentalFeatures class where you can change some behaviors to test them out:

First, I would suggest setting applyNeutralModeConstantlyInAuto to false. There is no reason to set neutral mode every iteration through autonomous periodic. And, in fact, those calls are blocking (and we need two for each module) so that can't be good for autonomous behavior.

The other things I added are:

applyDriverDeadband: This will apply a deadband to the driver joystick input. We're not currently using one, which means even the slightest joystick drift (non-zero value when "at rest") will be seen as an input. This might be the cause of the wheel rotation we saw on when you handled the joystick in a specific way. 

disableRotationWhenNotMoving: Couple with the above, this seeks to limit the movement of the wheels if the robot isn't being driven anywhere. The thinking is: why turn the wheels in a particular direction if there's no intention to move that direction. I'm using an EmptyControl request to "do nothing" in that case, but maybe it would be better to tell the steer motor to maintain its current position instead? You'll need to see how this makes it behave.

useCosineCompensation: This attempts to implement the cosine compensation strategy that I talked about in the Swerve Fundamentals class. The drive velocity will be scaled back towards zero the more the current position is out of alignment with respect to the desired direction of travel. 