### PR TITLE
Attempt to make the code blue alliance-centric

### DIFF
--- a/2024Crescendo/src/main/java/frc/robot/Robot.java
+++ b/2024Crescendo/src/main/java/frc/robot/Robot.java
@@ -35,7 +35,7 @@ public class Robot extends TimedRobot {
     // autonomous chooser on the dashboard.
     m_robotContainer = new RobotContainer();
     
-    m_robotContainer.resetSensors();
+    // This is already called in RobotContainer.init(): m_robotContainer.resetSensors();
     //CanandEventLoop.getInstance();
 
     // Turn brake mode off shortly after the robot is disabled

--- a/2024Crescendo/src/main/java/frc/robot/RobotContainer.java
+++ b/2024Crescendo/src/main/java/frc/robot/RobotContainer.java
@@ -177,8 +177,8 @@ public class RobotContainer {
     //shooter.setDefaultCommand(new InstantCommand(() -> shooter.stopMotors()));
     
     //CHASSIS
-    // Tell the Swerve system that it's facing forward
-    driverController.start().onTrue(new InstantCommand(() -> swerve.setHeading(new Rotation2d()), swerve));
+    // Tell the Swerve system that it's facing forward. For blue alliance, that's 0 degrees. For red alliance, that's 180 degrees.
+    driverController.start().onTrue(new InstantCommand(() -> swerve.setHeading(Rotation2d.fromDegrees(redAlliance ? 180 : 0)), swerve));
 
     // MDS: TODO: If everything is blue-alliance-relative, we probably want 90 degrees in both cases now,but I'm not entirely
     // sure what's going on this command.

--- a/2024Crescendo/src/main/java/frc/robot/RobotContainer.java
+++ b/2024Crescendo/src/main/java/frc/robot/RobotContainer.java
@@ -11,6 +11,7 @@ import com.pathplanner.lib.auto.NamedCommands;
 import com.reduxrobotics.canand.CanandEventLoop;
 
 import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.SwerveModulePosition;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
@@ -123,22 +124,50 @@ public class RobotContainer {
     new MovePivot(pivot, Constants.Pivot.INTAKE_SAFE);
   }
 
-  public void resetSensors() {
-    swerve.resetOdometry(new Pose2d(0.0, 0.0, swerve.getRotation2d()));
+  /**
+   * Return the driver joystick value for X input. This will be positive towards the red
+   * alliance, regardless of which alliance station we're using.
+   * @return X value
+   */
+  public double driverInputXBlueRelative() {
+    double rawValue = driverController.getRawAxis(1);
+    return redAlliance ? rawValue : -rawValue;
+  }
+
+  /**
+   * Return the driver joystick value for Y input. This will be positive towards the left
+   * wall relative to the blue alliance, regardless of which alliance station we're using.
+   * @return Y value
+   */
+  public double driverInputYBlueRelative() {
+    double rawValue = driverController.getRawAxis(0);
+    return redAlliance ? rawValue : -rawValue;
+  }
+
+  /**
+   * Return the driver joystick value for theta input. This will be positive for counterclockwise 
+   * rotation when the joystick is pushed left regardless of which alliance station we're on.
+   * @return theta value
+   */
+  public double driverInputThetaBlueRelative() {
+    double rawValue = driverController.getRawAxis(4);
+    return redAlliance ? rawValue : -rawValue;
+  }
+
+  private void resetSensors() {
+    // Reset odometry to reflect that the robot is facing the red alliance wall. Odometry will be 
+    // reset when auto starts with the correct pose.
+    swerve.resetOdometry(new Pose2d(0.0, 0.0, new Rotation2d()));
 
     swerve.frontLeft.resetEncoder();
     swerve.frontRight.resetEncoder();
     swerve.backLeft.resetEncoder();
     swerve.backRight.resetEncoder();
-    swerve.odometry.update(swerve.getRotation2d(), new SwerveModulePosition[] {
-      swerve.frontLeft.getPosition(), swerve.frontRight.getPosition(), swerve.backLeft.getPosition(), swerve.backRight.getPosition()
-    });;
   }
-  
+
   private void configureBindings() {
     //DEFAULT COMMANDS
-    swerve.setDefaultCommand(new SwerveDrive(swerve, () -> -driverController.getRawAxis(1),
-      () -> -driverController.getRawAxis(0), () -> -driverController.getRawAxis(4)));
+    swerve.setDefaultCommand(new SwerveDrive(swerve, () -> driverInputXBlueRelative(), () -> driverInputYBlueRelative(), () -> driverInputThetaBlueRelative()));
     
     leftClimb.setDefaultCommand(new ManualClimb(() -> operatorController.getRightY(), leftClimb));
     rightClimb.setDefaultCommand(new ManualClimb(() -> operatorController.getLeftY(), rightClimb));
@@ -148,8 +177,11 @@ public class RobotContainer {
     //shooter.setDefaultCommand(new InstantCommand(() -> shooter.stopMotors()));
     
     //CHASSIS
-    driverController.start().onTrue(new InstantCommand(() -> swerve.resetGyro(), swerve));
+    // Tell the Swerve system that it's facing forward
+    driverController.start().onTrue(new InstantCommand(() -> swerve.setHeading(new Rotation2d()), swerve));
 
+    // MDS: TODO: If everything is blue-alliance-relative, we probably want 90 degrees in both cases now,but I'm not entirely
+    // sure what's going on this command.
     driverController.leftTrigger().whileTrue(new WallSnapDrive(swerve, () -> -driverController.getRawAxis(1), () -> -driverController.getRawAxis(0), ()->0));
     //adjust for blue alliance
     driverController.rightTrigger().whileTrue(new WallSnapDrive(swerve, () -> -driverController.getRawAxis(1), () -> -driverController.getRawAxis(0), ()->270));

--- a/2024Crescendo/src/main/java/frc/robot/commands/AmpReverse.java
+++ b/2024Crescendo/src/main/java/frc/robot/commands/AmpReverse.java
@@ -43,17 +43,9 @@ public class AmpReverse extends Command {
   public void execute() {
     SmartDashboard.putNumber("Initial Position", initialEncPosition);
 
-    if(RobotContainer.redAlliance){
-      double ySpeed = cleanAndScaleInput(0.00, Constants.Swerve.AMP_REVERSE_JS_INPUT, yLimiter, (Constants.Swerve.SWERVE_MAX_SPEED)/2);
-      ChassisSpeeds chassisSpeeds = ChassisSpeeds.fromFieldRelativeSpeeds(0, ySpeed, 0, swerve.getRotation2d());
-      SwerveModuleState[] moduleState = Constants.Swerve.SWERVE_DRIVE_KINEMATICS.toSwerveModuleStates(chassisSpeeds);
-      swerve.setModuleStates(moduleState);
-    }else{
-      double ySpeed = cleanAndScaleInput(0.00, -Constants.Swerve.AMP_REVERSE_JS_INPUT, yLimiter, (Constants.Swerve.SWERVE_MAX_SPEED)/2);
-      ChassisSpeeds chassisSpeeds = ChassisSpeeds.fromFieldRelativeSpeeds(0, ySpeed, 0, swerve.getRotation2d());
-      SwerveModuleState[] moduleState = Constants.Swerve.SWERVE_DRIVE_KINEMATICS.toSwerveModuleStates(chassisSpeeds);
-      swerve.setModuleStates(moduleState);
-    }
+    // Swerve now operates blue-relative all the time, so backing up is always negative Y movement regardless of the alliance we're on
+    double ySpeed = cleanAndScaleInput(0.00, -Constants.Swerve.AMP_REVERSE_JS_INPUT, yLimiter, (Constants.Swerve.SWERVE_MAX_SPEED)/2);
+    swerve.driveFieldRelative(0, ySpeed, 0);
 
     SmartDashboard.putBoolean("What Alliance", RobotContainer.redAlliance);
     

--- a/2024Crescendo/src/main/java/frc/robot/commands/SwerveDrive.java
+++ b/2024Crescendo/src/main/java/frc/robot/commands/SwerveDrive.java
@@ -7,6 +7,7 @@ import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.Constants;
+import frc.robot.RobotContainer;
 import frc.robot.subsystems.Swerve;
 
 public class SwerveDrive extends Command {
@@ -36,9 +37,8 @@ public class SwerveDrive extends Command {
     double xSpeed = cleanAndScaleInput(deadband, xSupplier.getAsDouble(), xLimiter, Constants.Swerve.SWERVE_MAX_SPEED);
     double ySpeed = cleanAndScaleInput(deadband, ySupplier.getAsDouble(), yLimiter, Constants.Swerve.SWERVE_MAX_SPEED);
     double rotationSpeed = cleanAndScaleInput(deadband, rotationSupplier.getAsDouble(), rotationLimiter, Constants.Swerve.SWERVE_ROTATION_MAX_SPEED_IN_RAD);
-    ChassisSpeeds chassisSpeeds = ChassisSpeeds.fromFieldRelativeSpeeds(xSpeed, ySpeed, rotationSpeed, swerve.getRotation2d());
-    SwerveModuleState[] moduleState = Constants.Swerve.SWERVE_DRIVE_KINEMATICS.toSwerveModuleStates(chassisSpeeds);
-    swerve.setModuleStates(moduleState);   
+
+    swerve.driveFieldRelative(xSpeed, ySpeed, rotationSpeed);
   }
 
   @Override

--- a/2024Crescendo/src/main/java/frc/robot/commands/VisionAlign.java
+++ b/2024Crescendo/src/main/java/frc/robot/commands/VisionAlign.java
@@ -36,17 +36,13 @@ public class VisionAlign extends Command {
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
+    double xSpeed;
     if (vision. getOffset() > 0){
-      double xSpeed = cleanAndScaleInput(0, 0.35, xLimiter, Constants.Swerve.SWERVE_MAX_SPEED);
-      ChassisSpeeds chassisSpeeds = ChassisSpeeds.fromFieldRelativeSpeeds(xSpeed, 0.0, 0.0, swerve.getRotation2d());
-      SwerveModuleState[] moduleState = Constants.Swerve.SWERVE_DRIVE_KINEMATICS.toSwerveModuleStates(chassisSpeeds);
-      swerve.setModuleStates(moduleState);
+      xSpeed = cleanAndScaleInput(0, 0.35, xLimiter, Constants.Swerve.SWERVE_MAX_SPEED);
     }else{
-      double xSpeed = cleanAndScaleInput(0, -0.35, xLimiter, Constants.Swerve.SWERVE_MAX_SPEED);
-      ChassisSpeeds chassisSpeeds = ChassisSpeeds.fromFieldRelativeSpeeds(xSpeed, 0.0, 0.0, swerve.getRotation2d());
-      SwerveModuleState[] moduleState = Constants.Swerve.SWERVE_DRIVE_KINEMATICS.toSwerveModuleStates(chassisSpeeds);
-      swerve.setModuleStates(moduleState);
+      xSpeed = cleanAndScaleInput(0, -0.35, xLimiter, Constants.Swerve.SWERVE_MAX_SPEED);
     }
+    swerve.driveFieldRelative(xSpeed, 0, 0);
   }
 
   // Called once the command ends or is interrupted.

--- a/2024Crescendo/src/main/java/frc/robot/commands/VisionAlignZ.java
+++ b/2024Crescendo/src/main/java/frc/robot/commands/VisionAlignZ.java
@@ -39,17 +39,9 @@ public class VisionAlignZ extends Command {
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
-    if (vision.getAlliance()){
-      double ySpeed = cleanAndScaleInput(0, -0.35, yLimiter, Constants.Swerve.SWERVE_MAX_SPEED);
-      ChassisSpeeds chassisSpeeds = ChassisSpeeds.fromFieldRelativeSpeeds(0, ySpeed, 0.0, swerve.getRotation2d());
-      SwerveModuleState[] moduleState = Constants.Swerve.SWERVE_DRIVE_KINEMATICS.toSwerveModuleStates(chassisSpeeds);
-      swerve.setModuleStates(moduleState);
-    }else{
-      double ySpeed = cleanAndScaleInput(0, 0.35, yLimiter, Constants.Swerve.SWERVE_MAX_SPEED);
-      ChassisSpeeds chassisSpeeds = ChassisSpeeds.fromFieldRelativeSpeeds(0.0, ySpeed, 0.0, swerve.getRotation2d());
-      SwerveModuleState[] moduleState = Constants.Swerve.SWERVE_DRIVE_KINEMATICS.toSwerveModuleStates(chassisSpeeds);
-      swerve.setModuleStates(moduleState);
-    }
+    // The Swerve subsystem always operates blue-alliance-relative, so we're always moving in forward Y direction
+    double ySpeed = cleanAndScaleInput(0, 0.35, yLimiter, Constants.Swerve.SWERVE_MAX_SPEED);
+    swerve.driveFieldRelative(0, ySpeed, 0);
   }
 
   // Called once the command ends or is interrupted.

--- a/2024Crescendo/src/main/java/frc/robot/commands/WallSnapDrive.java
+++ b/2024Crescendo/src/main/java/frc/robot/commands/WallSnapDrive.java
@@ -32,7 +32,7 @@ public class WallSnapDrive extends Command {
 
   private double currentHeading() {
     // return swerve.getRotation2d().getDegrees();
-    return swerve.getRotation2d().getDegrees();
+    return swerve.getHeading().getDegrees();
   }
 
   public void initialize() {
@@ -49,30 +49,23 @@ public class WallSnapDrive extends Command {
   }
 
   public void execute() {
+    double xSpeed, ySpeed, desiredHeading, rotSpeed;
+
     if(RobotContainer.redAlliance && headingSupplier.getAsDouble()==270){
-        double xSpeed = cleanAndScaleInput(0.00, xSupplier.getAsDouble(), Constants.Swerve.SWERVE_MAX_SPEED);
-        double ySpeed = cleanAndScaleInput(0.00, ySupplier.getAsDouble(), Constants.Swerve.SWERVE_MAX_SPEED);
+        xSpeed = cleanAndScaleInput(0.00, xSupplier.getAsDouble(), Constants.Swerve.SWERVE_MAX_SPEED);
+        ySpeed = cleanAndScaleInput(0.00, ySupplier.getAsDouble(), Constants.Swerve.SWERVE_MAX_SPEED);
 
-        double desiredHeading = headingSupplier.getAsDouble() != -1 ? (headingSupplier.getAsDouble()-180) : lastHeading;
-        double rotSpeed = angleController.calculate(currentHeading(), desiredHeading);
-
-        ChassisSpeeds chassisSpeeds = ChassisSpeeds.fromFieldRelativeSpeeds(xSpeed, ySpeed, rotSpeed, swerve.getRotation2d());
-        SwerveModuleState[] moduleState = Constants.Swerve.SWERVE_DRIVE_KINEMATICS.toSwerveModuleStates(chassisSpeeds);
-        SwerveDriveKinematics.desaturateWheelSpeeds(moduleState, Constants.Swerve.SWERVE_MAX_SPEED);
-        swerve.setModuleStates(moduleState);
+        desiredHeading = headingSupplier.getAsDouble() != -1 ? (headingSupplier.getAsDouble()-180) : lastHeading;
+        rotSpeed = angleController.calculate(currentHeading(), desiredHeading);
     }else{
-        double xSpeed = cleanAndScaleInput(0.00, xSupplier.getAsDouble(), Constants.Swerve.SWERVE_MAX_SPEED);
-        double ySpeed = cleanAndScaleInput(0.00, ySupplier.getAsDouble(), Constants.Swerve.SWERVE_MAX_SPEED);
+        xSpeed = cleanAndScaleInput(0.00, xSupplier.getAsDouble(), Constants.Swerve.SWERVE_MAX_SPEED);
+        ySpeed = cleanAndScaleInput(0.00, ySupplier.getAsDouble(), Constants.Swerve.SWERVE_MAX_SPEED);
 
-        double desiredHeading = headingSupplier.getAsDouble() != -1 ? headingSupplier.getAsDouble() : lastHeading;
-        double rotSpeed = angleController.calculate(currentHeading(), desiredHeading);
-
-        ChassisSpeeds chassisSpeeds = ChassisSpeeds.fromFieldRelativeSpeeds(xSpeed, ySpeed, rotSpeed, swerve.getRotation2d());
-        SwerveModuleState[] moduleState = Constants.Swerve.SWERVE_DRIVE_KINEMATICS.toSwerveModuleStates(chassisSpeeds);
-        SwerveDriveKinematics.desaturateWheelSpeeds(moduleState, Constants.Swerve.SWERVE_MAX_SPEED);
-        swerve.setModuleStates(moduleState);
+        desiredHeading = headingSupplier.getAsDouble() != -1 ? headingSupplier.getAsDouble() : lastHeading;
+        rotSpeed = angleController.calculate(currentHeading(), desiredHeading);
     }
-    
+
+    swerve.driveFieldRelative(xSpeed, ySpeed, rotSpeed);
   }
 
   public void end (boolean interrupted) {

--- a/2024Crescendo/src/main/java/frc/robot/subsystems/Swerve.java
+++ b/2024Crescendo/src/main/java/frc/robot/subsystems/Swerve.java
@@ -88,9 +88,32 @@ public class Swerve extends SubsystemBase{
     return pose;
   }
 
-  /** @return The degrees of pigeon gyro (heading of the robot) as a Rotation2d */
-  public Rotation2d getRotation2d() {
+  /**
+   * Returns the reading of the gyroscope. We use this for updating odometry. Code that wants to know what direction the
+   * robot is facing should use getHeading() instead.
+   * @return The degrees of pigeon gyro (heading of the robot) as a Rotation2d 
+   */
+  private Rotation2d getRotation2d() {
     return gyro.getRotation2d();
+  }
+
+  /**
+   * Returns the heading of the robot relative to the field. We use this for calculating robot relative fields. Odometry updates
+   * should call getRotation2d() instead.
+   * @return The degrees of rotation relative to the field. 
+   */
+  public Rotation2d getHeading() {
+    return getPose().getRotation();
+  }
+
+  /**
+   * Sets the heading of the robot. It does this by resetting odometry with a new pose at the same location, but with the corrected
+   * heading. It does not reset module positions or the gyroscope angle. Odometry handles that for us.
+   * @param fieldRelativeRotation The degrees of rotation relative to the field. 
+   */
+  public void setHeading(Rotation2d fieldRelativeRotation) {
+    Pose2d newPose = new Pose2d(pose.getTranslation(), fieldRelativeRotation);
+    resetOdometry(newPose);
   }
 
   public SwerveModuleState[] getModuleStates() {
@@ -131,13 +154,37 @@ public class Swerve extends SubsystemBase{
     this.setModuleStates(moduleState);
   }
 
+  /**
+   * Instructs the swerve subsystem to drive using the given field-relative speeds. Field-relative speeds are
+   * relative to the blue alliance origin. So +x is in the direction of the red alliance wall. +y is toward the
+   * left wall when standing at a blue driver station.
+   * @param speeds Desired field-relative speeds
+   */
+  public void driveFieldRelative(ChassisSpeeds speeds) {
+    ChassisSpeeds robotRelative = ChassisSpeeds.fromFieldRelativeSpeeds(speeds, getHeading());
+    driveRobotRelative(robotRelative);
+  }
+
+  /**
+   * Instructs the swerve subsystem to drive using the given field-relative speeds. Field-relative speeds are
+   * relative to the blue alliance origin. So +x is in the direction of the red alliance wall. +y is toward the
+   * left wall when standing at a blue driver station.
+   * @param x Desired speed in the x direction
+   * @param y Desired speed in the y direction
+   * @param theta Desired rotation speed (counter-clockwise positive)
+   */
+  public void driveFieldRelative(double x, double y, double theta) {
+    ChassisSpeeds fieldRelativeSpeeds = new ChassisSpeeds(x, y, theta);
+    driveFieldRelative(fieldRelativeSpeeds);
+  }
+
   /** Resets robot position on the field */
   public void resetOdometry(Pose2d pose) {
     odometry.resetPosition(getRotation2d(), getModulePositions(), pose);
   }
 
   /** Resets pigeon gyro to 0 */
-  public void resetGyro () {
+  private void resetGyro () {
     gyro.reset();
   }
 


### PR DESCRIPTION
DO NOT JUST MERGE THIS: If you want to experiment with it, just use this branch, or merge it to an experimental branch.

In the Swerve workshop, I talked about how we should standardize on blue alliance-relative driving. We are decidedly not doing that. Here's a first stab at what it would look like if we converted the existing robot code to do this. I'm not suggesting that we try to make these kinds of changes before MadTown, but it would be good to keep this in mind for next year's robot. In particular, I think if we keep odometry correct, we can get the heading of the robot out of the odometry object instead of the gyro, and let odometry do the correct for us. I think this will mean that driving will be correct coming out of auto even if the robot starts at an angle.

* First, make it RobotContainer's job to figure out the proper orientation of the joystick input. When commands receive x/y/theta input, they have already been converted to blue-alliance-relative input. IOW, pushing forward on the stick on the red aliance will yield a negative X value, because we want to move toward the blue alliance, and that's negative from the blue alliance's perspective.
* Add driveFieldRelative method to Swerve subsystem so that commands can just ask the swerve system to drive, and the code to convert to robot relative speeds and then to swerve module states doesn't need to be repeated everywhere.
* The above allows us to make the gyro private to the Swerve subsystem.
* Introduce a new heading concept in Swerve -- the direction the robot is facing. This decouples that notiion from where zero is on the gyro. Odometry and Auto already correct for the gyro value, so if we just let odometry track the direction the robot is facing, drive direction should be correct coming out of automonous -- assuming the robot was actually placed in the orientation described by the starting pose.
* Update the "reset gyro button" to simply update odometry with a new blue-alliance-relative pose. For blue alliance, that'll be 0 degrees. For red alliance (facing blue), it'll be 180.